### PR TITLE
Update auth.config.json to handle several callbackURL

### DIFF
--- a/SlackReminder/auth.config.json
+++ b/SlackReminder/auth.config.json
@@ -6,8 +6,12 @@
     "access_type": "offline",
     "consent": true
   },
+  "tokenParams": {
+    "redirect_uri": "https://int.bearer.sh/v1/auth/callback"
+  },
   "config": {
     "accessType": "offline",
+    "callbackURL": "https://int.bearer.sh/v1/auth/callback",
     "scope": ["reminders:write", "channels:read", "groups:read", "users:read"]
   },
   "setupViews": [


### PR DESCRIPTION
The `callbackURL` needs to match the `redirect_uri` at the token exchange step. Otherwise Slack will complain and will select the first of the Allowed URLs in the list.