### PR TITLE
Evented back to back

### DIFF
--- a/NewSlack/spec.ts
+++ b/NewSlack/spec.ts
@@ -29,13 +29,6 @@ export default {
       label: 'Channel Action Component'
     },
     {
-      classname: 'ChannelDisplay',
-      isRoot: true,
-      initialTagName: 'channel-display',
-      group: 'channel',
-      label: 'Channel Display Component'
-    },
-    {
       classname: 'FeatureAction',
       isRoot: true,
       initialTagName: 'feature-action',

--- a/NewSlack/views/feature-action.tsx
+++ b/NewSlack/views/feature-action.tsx
@@ -26,10 +26,16 @@ export class FeatureAction {
   componentDidLoad() {
     Bearer.emitter.addListener(`bearer:StateSaved:${this.SCENARIO_ID}`, data => {
       this.channelId = data.detail.referenceId
+      this.notify({name: 'channelId', value: this.channelId})
     })
     Bearer.emitter.addListener(Events.AUTHORIZED, data => {
       this.authIdentifier = data.scenarioId.data.authIdentifier
+      this.notify({name: 'authIdentifier', value: this.authIdentifier})
     })
+  }
+
+  notify = params => {
+    Bearer.emitter.emit(`bearer:PropSet`, params)
   }
 
   perform = () => {

--- a/NewSlack/views/feature-action.tsx
+++ b/NewSlack/views/feature-action.tsx
@@ -1,4 +1,4 @@
-import Bearer, { RootComponent, Prop, Events, Intent, BearerFetch, State } from '@bearer/core'
+import Bearer, { RootComponent, Prop, Events, Event, EventEmitter, Intent, BearerFetch, State } from '@bearer/core'
 import '@bearer/ui'
 
 @RootComponent({
@@ -22,6 +22,8 @@ export class FeatureAction {
   error: boolean = false
   @State()
   shared: boolean = false
+  @Event()
+  propSet: EventEmitter
 
   componentDidLoad() {
     Bearer.emitter.addListener(`bearer:StateSaved:${this.SCENARIO_ID}`, data => {
@@ -35,7 +37,7 @@ export class FeatureAction {
   }
 
   notify = params => {
-    Bearer.emitter.emit(`bearer:PropSet`, params)
+    this.propSet.emit(params)
   }
 
   perform = () => {


### PR DESCRIPTION
Add some events when props are updated in dev portal.
Eventually we want to do this automatically for components that have mutable props.